### PR TITLE
feat: 샘플 페이지 추가

### DIFF
--- a/apps/web/src/constants/index.ts
+++ b/apps/web/src/constants/index.ts
@@ -18,6 +18,9 @@ const PATH = {
   TRADERS_ROOM: `/traders/${TRADERS_ROUTES.ROOM}`,
   TRADERS_ROOM_WAITING: `/traders/${TRADERS_ROUTES.ROOM_WAITING}`,
 
+  /* Sample 페이지 */
+  SAMPLE: '/sample',
+
   /* Sketch 하위 라우트 */
   SKETCH: '/sketch',
 

--- a/apps/web/src/pages/SamplePage/SamplePage.styles.ts
+++ b/apps/web/src/pages/SamplePage/SamplePage.styles.ts
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #0a0a0a;
+  color: #ffffff;
+`;
+
+export const Title = styled.h1`
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+`;
+
+export const Description = styled.p`
+  font-size: 1.125rem;
+  color: #a0a0a0;
+  max-width: 480px;
+  text-align: center;
+  line-height: 1.6;
+`;

--- a/apps/web/src/pages/SamplePage/SamplePage.styles.ts
+++ b/apps/web/src/pages/SamplePage/SamplePage.styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.div`
+const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -10,16 +10,18 @@ export const Container = styled.div`
   color: #ffffff;
 `;
 
-export const Title = styled.h1`
+const Title = styled.h1`
   font-size: 2.5rem;
   font-weight: 700;
   margin-bottom: 1rem;
 `;
 
-export const Description = styled.p`
+const Description = styled.p`
   font-size: 1.125rem;
   color: #a0a0a0;
   max-width: 480px;
   text-align: center;
   line-height: 1.6;
 `;
+
+export { Container, Title, Description };

--- a/apps/web/src/pages/SamplePage/index.tsx
+++ b/apps/web/src/pages/SamplePage/index.tsx
@@ -1,0 +1,18 @@
+import Layout from '@/components/Layout';
+
+import * as S from './SamplePage.styles';
+
+const SamplePage = () => {
+  return (
+    <Layout>
+      <S.Container>
+        <S.Title>Sample Page</S.Title>
+        <S.Description>
+          Claude Code PR 테스트를 위한 샘플 페이지입니다.
+        </S.Description>
+      </S.Container>
+    </Layout>
+  );
+};
+
+export default SamplePage;

--- a/apps/web/src/routes/RouteProvider.tsx
+++ b/apps/web/src/routes/RouteProvider.tsx
@@ -14,6 +14,7 @@ import AriaRolePage from '@/pages/A11yPage/AriaRolePage';
 import KeyboardPage from '@/pages/A11yPage/KeyboardPage';
 import SemanticPage from '@/pages/A11yPage/SemanticPage';
 import HomePage from '@/pages/HomePage';
+import SamplePage from '@/pages/SamplePage';
 import SketchPage from '@/pages/SketchPage';
 import TradersPage from '@/pages/TradersPage';
 import FloatingThemeToggle from '@/pages/TradersPage/components/FloatingThemeToggle';
@@ -74,6 +75,10 @@ const router = createBrowserRouter([
             element: <RoomWaitingPage />,
           },
         ],
+      },
+      {
+        path: PATH.SAMPLE,
+        element: <SamplePage />,
       },
       {
         path: PATH.SKETCH,


### PR DESCRIPTION
## Summary
- Claude Code PR 생성 테스트를 위한 샘플 페이지를 추가했습니다.
- `/sample` 경로로 접근 가능한 SamplePage 컴포넌트를 생성하고 라우트에 등록했습니다.

## Changes
- `apps/web/src/pages/SamplePage/index.tsx` — SamplePage 컴포넌트 생성
- `apps/web/src/pages/SamplePage/SamplePage.styles.ts` — Emotion 스타일 정의
- `apps/web/src/constants/index.ts` — PATH.SAMPLE 경로 상수 추가
- `apps/web/src/routes/RouteProvider.tsx` — SamplePage 라우트 등록

## Test plan
- [ ] `/sample` 경로로 접근 시 페이지 정상 렌더링 확인
- [ ] 기존 라우트에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)