### PR TITLE
feat: 404 NotFoundPage 커스텀 페이지 추가

### DIFF
--- a/apps/web/src/pages/NotFoundPage/NotFoundPage.styles.ts
+++ b/apps/web/src/pages/NotFoundPage/NotFoundPage.styles.ts
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #0a0a0a;
+  color: #ffffff;
+  gap: 1.5rem;
+`;
+
+const ErrorCode = styled.h1`
+  font-size: 6rem;
+  font-weight: 800;
+  color: #333333;
+  margin: 0;
+`;
+
+const Message = styled.p`
+  font-size: 1.25rem;
+  color: #a0a0a0;
+`;
+
+const HomeLink = styled.a`
+  padding: 0.75rem 2rem;
+  border: 1px solid #333333;
+  border-radius: 8px;
+  color: #ffffff;
+  text-decoration: none;
+  transition: background 0.2s;
+
+  &:hover {
+    background: #1a1a1a;
+  }
+`;
+
+export { Container, ErrorCode, Message, HomeLink };

--- a/apps/web/src/pages/NotFoundPage/index.tsx
+++ b/apps/web/src/pages/NotFoundPage/index.tsx
@@ -1,0 +1,15 @@
+import { PATH } from '@/constants';
+
+import * as S from './NotFoundPage.styles';
+
+const NotFoundPage = () => {
+  return (
+    <S.Container>
+      <S.ErrorCode>404</S.ErrorCode>
+      <S.Message>페이지를 찾을 수 없습니다.</S.Message>
+      <S.HomeLink href={PATH.ROOT}>홈으로 돌아가기</S.HomeLink>
+    </S.Container>
+  );
+};
+
+export default NotFoundPage;

--- a/apps/web/src/routes/RouteProvider.tsx
+++ b/apps/web/src/routes/RouteProvider.tsx
@@ -14,6 +14,7 @@ import AriaRolePage from '@/pages/A11yPage/AriaRolePage';
 import KeyboardPage from '@/pages/A11yPage/KeyboardPage';
 import SemanticPage from '@/pages/A11yPage/SemanticPage';
 import HomePage from '@/pages/HomePage';
+import NotFoundPage from '@/pages/NotFoundPage';
 import SketchPage from '@/pages/SketchPage';
 import TradersPage from '@/pages/TradersPage';
 import FloatingThemeToggle from '@/pages/TradersPage/components/FloatingThemeToggle';
@@ -101,7 +102,7 @@ const router = createBrowserRouter([
       },
       {
         path: '*',
-        element: <SomethingWentWrong />,
+        element: <NotFoundPage />,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- 기존 와일드카드 라우트(`*`)에서 사용하던 `SomethingWentWrong` 컴포넌트를 전용 `NotFoundPage`로 교체했습니다.
- 404 에러 코드, 안내 메시지, 홈으로 돌아가기 링크를 제공합니다.

## Changes
- `apps/web/src/pages/NotFoundPage/index.tsx` — NotFoundPage 컴포넌트 생성
- `apps/web/src/pages/NotFoundPage/NotFoundPage.styles.ts` — 스타일 정의
- `apps/web/src/routes/RouteProvider.tsx` — 와일드카드 라우트 컴포넌트 교체

## Test plan
- [ ] 존재하지 않는 경로 접근 시 404 페이지 렌더링 확인
- [ ] 홈으로 돌아가기 링크 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)