### PR TITLE
feat: 공통 Badge 컴포넌트 추가

### DIFF
--- a/apps/web/src/components/Badge/Badge.styles.ts
+++ b/apps/web/src/components/Badge/Badge.styles.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+interface BadgeStyleProps {
+  variant: 'default' | 'success' | 'warning' | 'error';
+}
+
+const VARIANT_COLORS = {
+  default: { bg: '#1a1a2e', color: '#8888aa' },
+  success: { bg: '#0a2e1a', color: '#44cc88' },
+  warning: { bg: '#2e2a0a', color: '#ccaa44' },
+  error: { bg: '#2e0a0a', color: '#cc4444' },
+};
+
+const Container = styled.span<BadgeStyleProps>`
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: ${({ variant }) => VARIANT_COLORS[variant].bg};
+  color: ${({ variant }) => VARIANT_COLORS[variant].color};
+`;
+
+export { Container };
+export type { BadgeStyleProps };

--- a/apps/web/src/components/Badge/index.tsx
+++ b/apps/web/src/components/Badge/index.tsx
@@ -1,0 +1,11 @@
+import { Container, BadgeStyleProps } from './Badge.styles';
+
+interface BadgeProps extends BadgeStyleProps {
+  children: React.ReactNode;
+}
+
+const Badge = ({ variant = 'default', children }: BadgeProps) => {
+  return <Container variant={variant}>{children}</Container>;
+};
+
+export default Badge;


### PR DESCRIPTION
## Summary
- default, success, warning, error 4가지 variant를 지원하는 공통 Badge 컴포넌트를 추가했습니다.

## Changes
- `apps/web/src/components/Badge/index.tsx` — Badge 컴포넌트 생성
- `apps/web/src/components/Badge/Badge.styles.ts` — variant별 스타일 정의

## Test plan
- [ ] 각 variant별 Badge 렌더링 확인
- [ ] children 텍스트 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)