### PR TITLE
feat: Badge를 활용한 StatusPage 추가

### DIFF
--- a/apps/web/src/components/Badge/Badge.styles.ts
+++ b/apps/web/src/components/Badge/Badge.styles.ts
@@ -5,10 +5,10 @@ interface BadgeStyleProps {
 }
 
 const VARIANT_COLORS = {
-  default: { bg: '#1a1a2e', color: '#8888aa' },
-  success: { bg: '#0a2e1a', color: '#44cc88' },
-  warning: { bg: '#2e2a0a', color: '#ccaa44' },
-  error: { bg: '#2e0a0a', color: '#cc4444' },
+  default: { bg: '#2a2a3e', color: '#aaaacc' },
+  success: { bg: '#0d3b22', color: '#34d399' },
+  warning: { bg: '#3b3510', color: '#fbbf24' },
+  error: { bg: '#3b1010', color: '#f87171' },
 };
 
 const Container = styled.span<BadgeStyleProps>`

--- a/apps/web/src/constants/index.ts
+++ b/apps/web/src/constants/index.ts
@@ -18,6 +18,9 @@ const PATH = {
   TRADERS_ROOM: `/traders/${TRADERS_ROUTES.ROOM}`,
   TRADERS_ROOM_WAITING: `/traders/${TRADERS_ROUTES.ROOM_WAITING}`,
 
+  /* Status 페이지 */
+  STATUS: '/status',
+
   /* Sketch 하위 라우트 */
   SKETCH: '/sketch',
 

--- a/apps/web/src/pages/StatusPage/StatusPage.styles.ts
+++ b/apps/web/src/pages/StatusPage/StatusPage.styles.ts
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #0a0a0a;
+  color: #ffffff;
+  gap: 2rem;
+`;
+
+const Title = styled.h1`
+  font-size: 2rem;
+  font-weight: 700;
+`;
+
+const StatusList = styled.ul`
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 400px;
+`;
+
+const StatusItem = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid #1a1a1a;
+  border-radius: 8px;
+`;
+
+const ServiceName = styled.span`
+  font-size: 1rem;
+  color: #cccccc;
+`;
+
+export { Container, Title, StatusList, StatusItem, ServiceName };

--- a/apps/web/src/pages/StatusPage/index.tsx
+++ b/apps/web/src/pages/StatusPage/index.tsx
@@ -1,0 +1,31 @@
+import Badge from '@/components/Badge';
+import Layout from '@/components/Layout';
+
+import * as S from './StatusPage.styles';
+
+const SERVICES = [
+  { name: 'API Server', status: 'success' as const, label: '정상' },
+  { name: 'Database', status: 'success' as const, label: '정상' },
+  { name: 'CDN', status: 'warning' as const, label: '지연' },
+  { name: 'Auth Service', status: 'error' as const, label: '장애' },
+];
+
+const StatusPage = () => {
+  return (
+    <Layout>
+      <S.Container>
+        <S.Title>서비스 상태</S.Title>
+        <S.StatusList>
+          {SERVICES.map((service) => (
+            <S.StatusItem key={service.name}>
+              <S.ServiceName>{service.name}</S.ServiceName>
+              <Badge variant={service.status}>{service.label}</Badge>
+            </S.StatusItem>
+          ))}
+        </S.StatusList>
+      </S.Container>
+    </Layout>
+  );
+};
+
+export default StatusPage;

--- a/apps/web/src/routes/RouteProvider.tsx
+++ b/apps/web/src/routes/RouteProvider.tsx
@@ -15,6 +15,7 @@ import KeyboardPage from '@/pages/A11yPage/KeyboardPage';
 import SemanticPage from '@/pages/A11yPage/SemanticPage';
 import HomePage from '@/pages/HomePage';
 import SketchPage from '@/pages/SketchPage';
+import StatusPage from '@/pages/StatusPage';
 import TradersPage from '@/pages/TradersPage';
 import FloatingThemeToggle from '@/pages/TradersPage/components/FloatingThemeToggle';
 import GameCompletePage from '@/pages/TradersPage/GameCompletePage';
@@ -74,6 +75,10 @@ const router = createBrowserRouter([
             element: <RoomWaitingPage />,
           },
         ],
+      },
+      {
+        path: PATH.STATUS,
+        element: <StatusPage />,
       },
       {
         path: PATH.SKETCH,


### PR DESCRIPTION
## Summary
- A 브랜치(feature/badge-component)에서 만든 Badge 컴포넌트를 활용하여 서비스 상태 페이지를 추가했습니다.
- 각 서비스의 상태를 Badge variant(success, warning, error)로 시각적으로 표시합니다.

## Changes
- `apps/web/src/pages/StatusPage/index.tsx` — StatusPage 컴포넌트 생성 (Badge 사용)
- `apps/web/src/pages/StatusPage/StatusPage.styles.ts` — 스타일 정의
- `apps/web/src/constants/index.ts` — PATH.STATUS 경로 추가
- `apps/web/src/routes/RouteProvider.tsx` — StatusPage 라우트 등록

## Note
- 이 PR은 `feature/badge-component` (PR #7) 를 base로 합니다.
- Badge 컴포넌트에 대한 리뷰 피드백은 이 브랜치에서 함께 반영할 예정입니다.

## Test plan
- [ ] /status 경로 접근 시 서비스 상태 목록 렌더링 확인
- [ ] Badge variant별 색상 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)