### PR TITLE
feat: HomePage 좌상단에 QuickStats 위젯 추가

### DIFF
--- a/apps/web/src/pages/HomePage/components/QuickStats.styles.ts
+++ b/apps/web/src/pages/HomePage/components/QuickStats.styles.ts
@@ -1,0 +1,73 @@
+import styled from '@emotion/styled';
+import { motion } from 'motion/react';
+
+import { mq } from '@cllaude99/ui/design-system/breakpoints';
+import { palette } from '@cllaude99/ui/design-system/palette';
+import { typography } from '@cllaude99/ui/design-system/typography';
+
+const QuickStatsZIndex = 20;
+
+export const Container = styled(motion.div)`
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  z-index: ${QuickStatsZIndex};
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  min-width: 140px;
+  background: linear-gradient(
+    135deg,
+    rgba(15, 15, 20, 0.65) 0%,
+    rgba(10, 10, 15, 0.55) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  pointer-events: none;
+  user-select: none;
+
+  ${mq.tablet} {
+    gap: 6px;
+    padding: 14px 18px;
+    min-width: 200px;
+    border-radius: 16px;
+  }
+`;
+
+export const Time = styled.div`
+  ${typography.label1Bold};
+  color: ${palette.white};
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+
+  ${mq.tablet} {
+    ${typography.heading4};
+    font-variant-numeric: tabular-nums;
+  }
+`;
+
+export const Date = styled.div`
+  ${typography.caption1};
+  color: ${palette.grey300};
+  font-size: 11px;
+
+  ${mq.tablet} {
+    ${typography.label2};
+  }
+`;
+
+export const ProjectCount = styled.div`
+  ${typography.caption1};
+  color: ${palette.grey400};
+  font-size: 11px;
+
+  ${mq.tablet} {
+    ${typography.label2};
+  }
+`;

--- a/apps/web/src/pages/HomePage/components/QuickStats.tsx
+++ b/apps/web/src/pages/HomePage/components/QuickStats.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+import { PROJECTS } from '@/constants';
+
+import * as S from './QuickStats.styles';
+
+const TIME_UPDATE_INTERVAL_MS = 1000;
+const KOREAN_DAYS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+function formatTime(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const dayOfWeek = KOREAN_DAYS[date.getDay()];
+  return `${year}.${month}.${day} (${dayOfWeek})`;
+}
+
+const QuickStats = () => {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const timerId = window.setInterval(() => {
+      setNow(new Date());
+    }, TIME_UPDATE_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(timerId);
+    };
+  }, []);
+
+  return (
+    <S.Container
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, ease: 'easeOut' }}
+    >
+      <S.Time>{formatTime(now)}</S.Time>
+      <S.Date>{formatDate(now)}</S.Date>
+      <S.ProjectCount>총 프로젝트 {PROJECTS.length}개</S.ProjectCount>
+    </S.Container>
+  );
+};
+
+export default QuickStats;

--- a/apps/web/src/pages/HomePage/index.tsx
+++ b/apps/web/src/pages/HomePage/index.tsx
@@ -9,6 +9,7 @@ import { PROJECTS } from '@/constants';
 
 import ParticleText from './components/ParticleText';
 import PlanetScene from './components/PlanetScene';
+import QuickStats from './components/QuickStats';
 import * as S from './HomePage.styles';
 
 const PARTICLE_TEXT_LINES = ['Cllaude99_Labs'];
@@ -23,6 +24,7 @@ const HomePage = () => {
         background: '#0a0a0a',
       }}
     >
+      <QuickStats />
       <S.Background />
       <S.Content>
         <S.Header


### PR DESCRIPTION
## Summary
- HomePage 좌상단에 `fixed` 글래스모피즘 위젯 `QuickStats` 추가 (top/left: 20px)
- 현재 시간(HH:MM:SS, 1초 간격 업데이트), 오늘 날짜(YYYY.MM.DD + 한국어 요일), `총 프로젝트 N개`(PROJECTS 상수 길이) 표시
- Emotion + Motion 기반, 마운트 시 페이드인(opacity + y -10) 애니메이션
- 모바일/태블릿(`mq.tablet`) 반응형 분기 적용

## Test plan
- [x] `pnpm lint` 통과 (기존 SketchPage 경고 1건 외 신규 오류 없음)
- [x] `pnpm type-check` 통과
- [x] `pnpm build` 통과
- [x] 로컬 dev 서버에서 위젯 노출/시간 갱신/반응형 동작 확인
- [ ] 데스크탑/태블릿/모바일 브레이크포인트별 시각적 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)