### PR TITLE
feat(home): 행성 네비게이션 위젯 추가

### DIFF
--- a/apps/web/src/pages/HomePage/components/PlanetNav.styles.ts
+++ b/apps/web/src/pages/HomePage/components/PlanetNav.styles.ts
@@ -1,0 +1,87 @@
+import styled from '@emotion/styled';
+import { motion } from 'motion/react';
+
+import { mq } from '@cllaude99/ui/design-system/breakpoints';
+import { palette } from '@cllaude99/ui/design-system/palette';
+import { typography } from '@cllaude99/ui/design-system/typography';
+
+const PlanetNavZIndex = 20;
+
+export const Nav = styled.nav`
+  display: none;
+
+  ${mq.tablet} {
+    position: fixed;
+    top: 50%;
+    right: 24px;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    padding: 14px 10px;
+    background: linear-gradient(
+      135deg,
+      rgba(15, 15, 20, 0.55) 0%,
+      rgba(10, 10, 15, 0.4) 100%
+    );
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    backdrop-filter: blur(8px);
+    box-shadow:
+      0 8px 24px rgba(0, 0, 0, 0.25),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    z-index: ${PlanetNavZIndex};
+  }
+`;
+
+export const DotWrapper = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+`;
+
+export const Dot = styled(motion.button)<{ isActive: boolean }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: ${({ isActive }) =>
+    isActive ? palette.blue400 : 'rgba(255, 255, 255, 0.35)'};
+  box-shadow: ${({ isActive }) =>
+    isActive
+      ? `0 0 12px ${palette.blue400}, 0 0 4px rgba(255, 255, 255, 0.6)`
+      : 'none'};
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: ${({ isActive }) =>
+      isActive ? palette.blue400 : 'rgba(255, 255, 255, 0.6)'};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${palette.blue300};
+    outline-offset: 4px;
+  }
+`;
+
+export const Tooltip = styled(motion.span)`
+  ${typography.label2};
+  position: absolute;
+  right: calc(100% + 14px);
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: rgba(10, 10, 15, 0.92);
+  color: ${palette.white};
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  white-space: nowrap;
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+`;

--- a/apps/web/src/pages/HomePage/components/PlanetNav.tsx
+++ b/apps/web/src/pages/HomePage/components/PlanetNav.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+import { AnimatePresence } from 'motion/react';
+
+import * as S from './PlanetNav.styles';
+
+interface Project {
+  id: number;
+  title: string;
+  description: string;
+  path: string;
+  techStack: string[];
+}
+
+interface PlanetNavProps {
+  currentIndex: number;
+  projects: Project[];
+  onIndexChange: (index: number) => void;
+}
+
+const DOT_SPRING = { type: 'spring' as const, stiffness: 400, damping: 28 };
+const ACTIVE_SCALE = 1.6;
+
+const PlanetNav = ({
+  currentIndex,
+  projects,
+  onIndexChange,
+}: PlanetNavProps) => {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+
+  return (
+    <S.Nav aria-label="프로젝트 네비게이션">
+      {projects.map((project, index) => {
+        const isActive = index === currentIndex;
+        const isTooltipVisible = hoveredIndex === index;
+
+        return (
+          <S.DotWrapper
+            key={project.id}
+            onMouseEnter={() => setHoveredIndex(index)}
+            onMouseLeave={() => setHoveredIndex(null)}
+          >
+            <S.Dot
+              type="button"
+              isActive={isActive}
+              animate={{ scale: isActive ? ACTIVE_SCALE : 1 }}
+              transition={DOT_SPRING}
+              onClick={() => onIndexChange(index)}
+              onFocus={() => setHoveredIndex(index)}
+              onBlur={() => setHoveredIndex(null)}
+              aria-label={`${project.title} 프로젝트로 이동`}
+              aria-current={isActive ? 'true' : undefined}
+            />
+            <AnimatePresence>
+              {isTooltipVisible && (
+                <S.Tooltip
+                  role="tooltip"
+                  initial={{ opacity: 0, x: 6 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 6 }}
+                  transition={{ duration: 0.18 }}
+                >
+                  {project.title}
+                </S.Tooltip>
+              )}
+            </AnimatePresence>
+          </S.DotWrapper>
+        );
+      })}
+    </S.Nav>
+  );
+};
+
+export default PlanetNav;

--- a/apps/web/src/pages/HomePage/index.tsx
+++ b/apps/web/src/pages/HomePage/index.tsx
@@ -8,6 +8,7 @@ import Layout from '@/components/Layout';
 import { PROJECTS } from '@/constants';
 
 import ParticleText from './components/ParticleText';
+import PlanetNav from './components/PlanetNav';
 import PlanetScene from './components/PlanetScene';
 import * as S from './HomePage.styles';
 
@@ -73,6 +74,11 @@ const HomePage = () => {
           ))}
         </Carousel>
       </S.Content>
+      <PlanetNav
+        currentIndex={currentIndex}
+        projects={PROJECTS}
+        onIndexChange={setCurrentIndex}
+      />
       <Dock />
     </Layout>
   );


### PR DESCRIPTION
## 개요

HomePage 우측 중앙에 프로젝트 인덱스를 시각화하는 행성 네비게이션 위젯을 추가합니다. Carousel/Planet3D와 `currentIndex` 상태를 공유하여, 닷 클릭만으로도 프로젝트 간 빠른 이동이 가능하도록 합니다.

## PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 작업 내용

### 🚨 [문제 상황]

- HomePage에서 프로젝트를 전환하려면 Carousel 스와이프 또는 3D Planet 클릭만 가능해, 현재 몇 번째 프로젝트인지 한눈에 파악하기 어려웠습니다.
- 데스크탑 사용자에게 빠른 점프 진입점이 부재했습니다.

### 🛠️ [문제 해결 과정]

- `apps/web/src/pages/HomePage/components/PlanetNav.tsx` 신규 생성 — `currentIndex`, `projects`, `onIndexChange` props 인터페이스로 외부에서 상태를 주입받는 stateless 위젯으로 설계.
- 스타일은 `PlanetNav.styles.ts`로 분리 (apps/web 패턴인 `import * as S` 네임스페이스 import 사용).
- `position: fixed; top: 50%; right: 24px` + Glass-morphism 컨테이너로 기존 ProjectInfo 톤과 통일.
- `mq.tablet` 미만에서 `display: none`으로 모바일 노출 제거.
- Active 닷은 `motion`의 spring 애니메이션(`stiffness: 400, damping: 28`)으로 1.6배 확대 + `palette.blue400` glow.
- 호버/포커스 시 좌측에 프로젝트 제목 툴팁(`AnimatePresence` 페이드+슬라이드) 표시.
- 접근성: `aria-label`, `aria-current`, `role="tooltip"`, `focus-visible` outline 적용.
- `HomePage/index.tsx`에서 Dock 바로 위로 마운트, 기존 `currentIndex`/`setCurrentIndex` 상태와 연결.

### 🎯 [결과]

- 데스크탑에서 우측 중앙에 닷 인디케이터로 현재 프로젝트 인덱스를 항상 시각화.
- 닷 클릭 → 즉시 인덱스 전환 → Carousel/Planet3D 동기화.
- 키보드 탐색(Tab + Enter)으로도 모든 닷 조작 가능.

## 스크린샷

<!-- 데스크탑/모바일 스크린샷 첨부 예정 -->

## 공유사항 to 리뷰어

- Active scale(1.6배)과 spring 파라미터(`stiffness/damping`)는 체감 튜닝 여지가 있습니다. 더 부드럽거나 더 톡톡 튀는 쪽으로 의견 주시면 조정하겠습니다.
- 현재 PROJECTS가 3개라 닷 3개만 노출되지만, 향후 5~6개 이상으로 늘면 닷 사이 gap(현재 18px) 재검토 필요할 수 있습니다.

## PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (`pnpm lint`, `pnpm type-check`, `pnpm build` 통과 + 로컬 dev 서버에서 UI 동작 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)